### PR TITLE
Feat: 봇 슬래시 명령 지원 추가

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -27,11 +27,11 @@ async def on_ready():
 @bot.event
 async def on_command_error(ctx, error):
     if isinstance(error, commands.CommandNotFound):
-        await ctx.send(f"❌ '{ctx.message.content}' 명령어를 찾을 수 없습니다. `!help`를 입력해보세요.")
+        await ctx.send(f"❌ '{ctx.message.content}' 명령어를 찾을 수 없습니다. `/도움`을 입력해보세요.")
     elif isinstance(error, commands.MissingPermissions):
         await ctx.send("❌ 이 명령어를 사용할 권한이 없습니다.")
     elif isinstance(error, commands.MissingRequiredArgument):
-        await ctx.send(f"❌ 필수 인수가 누락되었습니다. `!help {ctx.command}`를 확인해보세요.")
+        await ctx.send(f"❌ 필수 인수가 누락되었습니다. `/도움 {ctx.command}`을(를) 확인해보세요.")
     else:
         print(f"오류 발생: {error}")
         await ctx.send(f"❌ 명령어 실행 중 오류가 발생했습니다: {error}")
@@ -40,7 +40,8 @@ async def load_cogs():
     """모든 cog를 로드합니다."""
     cogs_to_load = [
         'cogs.hello',
-        'cogs.news'
+        'cogs.news',
+        'cogs.help'
     ]    
     
     for cog in cogs_to_load:

--- a/cogs/hello.py
+++ b/cogs/hello.py
@@ -4,7 +4,7 @@ class HelloCommand(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
     
-    @commands.command(name='안녕', help='인사해 줌')
+    @commands.command(name='안녕', help='봇이 인사를 합니다.')
     async def hello(self, ctx):
         await ctx.send(f'안녕하세요 {ctx.author.mention}님! 🎮\n롤, 발로란트의 이스포츠 뉴스를 알려드릴게요!')
 

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -1,0 +1,45 @@
+from discord.ext import commands
+import discord
+
+class GeneralHelp(commands.Cog):
+    """모든 Cog의 명령어를 한눈에 보여주는 도움말 Cog입니다."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    @commands.command(name='도움', help='모든 명령어를 보여줍니다.')
+    async def show_help(self, ctx: commands.Context):
+        """'/도움' 명령어 실행 시 호출되어, 봇에 등록된 모든 명령어를 Embed로 출력합니다."""
+
+        embed = discord.Embed(
+            title='📚 명령어 목록',
+            description='아래는 사용 가능한 명령어와 간단한 설명입니다.',
+            color=0x1E90FF
+        )
+
+        # 명령어를 알파벳순으로 정렬해 가독성 향상
+        for command in sorted(self.bot.commands, key=lambda c: c.name):
+            # 표시 제외 조건: 숨김 처리된 명령어나 내부용
+            if command.hidden:
+                continue
+
+            # 내부적으로 제거했지만 혹시 남아있을 수 있는 기본 help 제외
+            if command.name == 'help':
+                continue
+
+            # /도움 자신은 목록에 포함하지 않음
+            if command.name == '도움':
+                continue
+
+            # 명령어 시그니처(필수·옵션 인자) 포함해 가독성 향상
+            signature = f" {command.signature}" if command.signature else ""
+
+            help_text = command.help or '설명이 등록되지 않았습니다.'
+            embed.add_field(name=f'/{command.name}{signature}', value=help_text, inline=False)
+
+        await ctx.send(embed=embed)
+
+
+async def setup(bot: commands.Bot):
+    """봇이 Cog를 로드할 때 호출됩니다."""
+    await bot.add_cog(GeneralHelp(bot)) 

--- a/cogs/news.py
+++ b/cogs/news.py
@@ -106,7 +106,7 @@ class NewsCommand(commands.Cog):
         print(f"✅ [{now_done}] 뉴스 전송 완료 ({len(new_articles)}개)")
 
     
-    @commands.command(name='뉴스확인', help='즉시 새로운 뉴스를 확인합니다.')
+    @commands.command(name='뉴스확인', help='지금 바로 최신 e스포츠 뉴스를 가져옵니다.')
     async def check_news_now(self, ctx):
         """수동으로 뉴스를 확인합니다."""
         await ctx.send("🔍 뉴스를 확인하고 있습니다...")
@@ -133,7 +133,7 @@ class NewsCommand(commands.Cog):
             await ctx.send(f"❌ 뉴스 확인 중 오류가 발생했습니다: {e}")
 
 
-    @commands.command(name='뉴스채널', help='뉴스 알림을 받을 채널을 설정합니다.')
+    @commands.command(name='뉴스채널', help='뉴스 알림이 전송될 디스코드 채널을 지정합니다. (관리자 전용)')
     @commands.has_guild_permissions(manage_channels=True)
     async def set_news_channel(self, ctx, channel: discord.TextChannel = None):
         """뉴스 알림 채널을 설정합니다."""
@@ -157,29 +157,6 @@ class NewsCommand(commands.Cog):
         if new_articles:
             for art in new_articles:
                 await ctx.send(embed=self.create_news_embed(art))
-
-
-    @commands.command(name='뉴스도움', help='뉴스 봇 명령어 도움말을 표시합니다.')
-    async def news_help(self, ctx):
-        embed = discord.Embed(
-            title='📖 뉴스봇 명령어',
-            color=0x00ff56,
-            description="사용 가능한 뉴스 관련 명령어들입니다."
-        )
-
-        embed.add_field(
-            name='/뉴스확인',
-            value='즉시 오늘 날짜의 새로운 뉴스를 확인합니다.',
-            inline=False
-        )
-
-        embed.add_field(
-            name='/뉴스채널 [#채널]',
-            value='뉴스 알림을 받을 채널을 설정합니다. (관리자 권한 필요)',
-            inline=False
-        )
-
-        await ctx.send(embed=embed)
 
 
 async def setup(bot):


### PR DESCRIPTION
# 📄 변경 사항 요약
- 새 Cog cogs/help.py - /도움 입력 시 모든 봇 명령어를 Embed 로 출력
- 기본 /help 명령 제거 → 중복 방지, 안내는 /도움 하나로 통일
- cogs/news.py 의 /뉴스도움 명령 삭제 (기능 중복 해소)
- 각 명령어의 help= 설명 한글로 다듬어 가독성 향상
- bot.py 오류 메시지에서 !help → /도움 으로 안내 문구 수정
- BREAKING CHANGE: **기존 /뉴스도움 명령은 더 이상 제공되지 않습니다.**

## 🔗 관련 이슈
X