### PR TITLE
Feat: 스코어 embed가 포함된 /롤리그 명령 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,7 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+
+#file
+schedule_data.json

--- a/bot.py
+++ b/bot.py
@@ -41,7 +41,8 @@ async def load_cogs():
     cogs_to_load = [
         'cogs.hello',
         'cogs.news',
-        'cogs.help'
+        'cogs.help',
+        'cogs.schedule'
     ]    
     
     for cog in cogs_to_load:

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -21,7 +21,8 @@ class GeneralHelp(commands.Cog):
         cog_name_mapping = {
             "NewsCommand": "📰 뉴스 기능",
             "HelloCommand": "🎮 일반 기능",
-            "GeneralHelp": "❓ 도움말"
+            "GeneralHelp": "❓ 도움말",
+            "ScheduleCommand": "🗓️ 롤 리그 일정 조회 기능"
         }
 
         # Cog별로 명령어 그룹화
@@ -61,7 +62,13 @@ class GeneralHelp(commands.Cog):
                 # 뉴스 기능에는 사용 팁 추가
                 if cog_name == "NewsCommand":
                     command_list.append("💡 **사용 팁:** 뉴스는 20분마다 자동으로 새 기사가 전송됩니다")
-                    command_list.append("🔒 **권한 안내:** 뉴스채널설정은 채널 관리 권한이 필요합니다")
+                    command_list.append("🔒 **권한 안내:** 뉴스채널설정은 채널 관리 권한이 필요합니다\n")
+
+                # 일정 기능에는 사용 팁 추가
+                if cog_name == "ScheduleCommand":
+                    leagues = ", ".join(["LCK", "LPL", "LEC", "LCS", "MSI", "WORLDS", "LJL"])
+                    command_list.append(f"💡 **지원 리그:** {leagues}")
+                    command_list.append("⏱️ **4경기 조회 가능**, `/롤리그 LCK`과 같이 입력하세요")
 
                 embed.add_field(
                     name=category_name, 

--- a/cogs/schedule.py
+++ b/cogs/schedule.py
@@ -1,0 +1,138 @@
+from discord.ext import commands
+from crawlers.schedule_crawling import fetch_lol_league_schedule_months, fetch_monthly_league_schedule, parse_lol_month_days
+from datetime import datetime, timezone
+import discord
+import io
+import aiohttp
+from PIL import Image, ImageDraw, ImageFont
+
+LEAGUE_TYPE = {
+    "LCK": "lck",
+    "LPL": "lpl",
+    "LEC": "lec",
+    "LCS": "lcs",
+    "MSI": "msi",
+    "WORLDS": "wrl",
+    "LJL": "ljl",
+}
+
+class ScheduleCommand(commands.Cog):
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+    
+    @commands.command(name='롤리그', help='LoL 경기 일정 확인 (곧 시작할 4경기). 예) /롤리그 LCK')
+    async def show_schedule(self, ctx: commands.Context, league_str: str):
+        """다가오는 4경기 일정을 임베드로 표시합니다."""
+
+        league_key = league_str.upper()
+        if league_key not in LEAGUE_TYPE:
+            await ctx.send(f"❌ 지원하지 않는 리그입니다. 사용 가능: {', '.join(LEAGUE_TYPE.keys())}")
+            return
+
+        league_code = LEAGUE_TYPE[league_key]
+
+        # 날짜 기준값 (UTC)
+        now_dt = datetime.now(timezone.utc)
+        today_iso = now_dt.replace(hour=0, minute=0, second=0, microsecond=0).isoformat()
+        now_ym = now_dt.strftime("%Y-%m")
+
+        # 1) 월 목록 조회
+        year_str = now_dt.strftime("%Y")
+        months_resp = await fetch_lol_league_schedule_months(year_str, league_code)
+        months_list: list[str] = (months_resp or {}).get("content", [])
+
+        # 현재 달 포함 이후만 남김
+        months_list = [m for m in months_list if m >= now_ym]
+
+        upcoming: list[dict] = []
+
+        # 2) 월별 일정 수집
+        for ym in months_list:
+            month_resp = await fetch_monthly_league_schedule(ym, league_code)
+            if not month_resp:
+                continue
+            for match in parse_lol_month_days(month_resp):
+                if match["startDate"] and match["startDate"] >= today_iso:
+                    upcoming.append(match)
+            if len(upcoming) >= 4:
+                break
+
+        if not upcoming:
+            await ctx.send("❌ 예정된 경기를 찾지 못했습니다.")
+            return
+
+        # 3) 정렬 후 4경기 추출
+        upcoming.sort(key=lambda m: m["startDate"])
+        upcoming = upcoming[:4]
+
+        # 4) 이미지 배너 생성 및 Embed 전송
+
+        async def build_scoreboard(team1: dict, team2: dict, score1, score2):
+            """팀 로고와 점수를 조합한 PNG BytesIO 반환"""
+            async with aiohttp.ClientSession() as session:
+                async def fetch_img(url):
+                    async with session.get(url) as resp:
+                        if resp.status == 200:
+                            data = await resp.read()
+                            return Image.open(io.BytesIO(data)).convert("RGBA")
+                        raise ValueError("img dl fail")
+
+                img1 = await fetch_img(team1["img"])
+                img2 = await fetch_img(team2["img"])
+
+            # resize logos
+            size = (60, 60)
+            img1.thumbnail(size, Image.LANCZOS)
+            img2.thumbnail(size, Image.LANCZOS)
+
+            W, H = 400, 70
+            canvas = Image.new("RGBA", (W, H), (255, 255, 255, 0))
+            draw = ImageDraw.Draw(canvas)
+
+            # positions
+            y = (H - img1.height)//2
+            canvas.paste(img1, (10, y), img1)
+            canvas.paste(img2, (W - img2.width - 10, y), img2)
+
+            # font
+            try:
+                font = ImageFont.truetype("arial.ttf", 28)
+            except Exception:
+                font = ImageFont.load_default()
+
+            score_text = f"{score1 if score1 is not None else '-'} : {score2 if score2 is not None else '-'}"
+            try:
+                tw, th = draw.textsize(score_text, font=font)  # Pillow <10
+            except AttributeError:
+                bbox = draw.textbbox((0, 0), score_text, font=font)
+                tw, th = bbox[2] - bbox[0], bbox[3] - bbox[1]
+            draw.text(((W - tw)//2, (H - th)//2), score_text, fill="white", font=font, stroke_width=2, stroke_fill="black")
+
+            buf = io.BytesIO()
+            canvas.save(buf, format="PNG")
+            buf.seek(0)
+            return buf
+
+        for m in upcoming:
+            start_epoch = int(datetime.fromisoformat(m["startDate"]).timestamp())
+            date_rel = f"<t:{start_epoch}:R>"
+            date_abs = f"<t:{start_epoch}:F>"
+
+            title = f"{m['team1']} vs {m['team2']}"
+
+            desc_lines = [date_abs if m["status"] == "BEFORE" else f"{date_abs} | 종료"]
+
+            colour = discord.Colour.blue() if m["status"] == "BEFORE" else discord.Colour.green()
+
+            embed = discord.Embed(title=title, description="\n".join(desc_lines), colour=colour)
+
+            if m.get("team1Img") and m.get("team2Img"):
+                buf = await build_scoreboard({"img": m["team1Img"]}, {"img": m["team2Img"]}, m.get("score1"), m.get("score2"))
+                file = discord.File(buf, filename="score.png")
+                embed.set_image(url="attachment://score.png")
+                await ctx.send(file=file, embed=embed)
+            else:
+                await ctx.send(embed=embed)
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(ScheduleCommand(bot))

--- a/crawlers/news_crawling.py
+++ b/crawlers/news_crawling.py
@@ -31,7 +31,7 @@ def load_state() -> dict:
         dict: lastProcessedAt이 key 값으로 담긴 dict를 로드한 값.
     """
     if not STATE_FILE.exists():
-        return {"lastProcessedAt": 0}
+        return {}
     return orjson.loads(STATE_FILE.read_bytes())
 
 
@@ -75,7 +75,7 @@ async def lol_news_articles(formatted_date: str) -> List[Dict[str, Any]]:
                 content = data.get("content", [])
 
         # 이전에 가져왔던 롤 이스포츠 기사 중 마지막으로 처리한 기사의 시각을 불러옴.
-        lol_last_at = load_state().get("lol").get('lastProcessedAt', 0)
+        lol_last_at = load_state().get("lol", {}).get('lastProcessedAt', 0)
 
         # createdAt이 lol의 lastProcessedAt보다 큰(신규) 기사만 반환
         lol_new_articles = sorted(

--- a/crawlers/schedule_crawling.py
+++ b/crawlers/schedule_crawling.py
@@ -1,0 +1,191 @@
+import aiohttp
+from datetime import datetime, timezone
+
+
+_TEAM_NAME_KEYS = (
+    "teamCode",
+    "nameAcronym",
+    "shortName",
+    "nameEng",
+    "name",
+)
+
+# 팀 로고용 이미지 URL 후보 키
+_TEAM_IMG_KEYS = (
+    "imageUrl",
+    "colorImageUrl",
+    "whiteImageUrl",
+    "blackImageUrl",
+)
+
+async def fetch_lol_league_schedule_months(year_str: str, league_str: str):
+    url = 'https://esports-api.game.naver.com/service/v1/schedule/year/months'
+
+    params = {
+        'year': year_str,
+        'topLeagueId': league_str,
+        'relay': 'false'
+    }
+
+    headers = {
+        'origin': 'https://game.naver.com',
+        'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Whale/4.32.315.22 Safari/537.36'
+    }
+
+
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url, params=params, headers=headers) as response:
+            if response.status == 200:
+                data = await response.json()
+                return data
+            else:
+                response_text = await response.text()
+                print(f"❌ 롤 일정 크롤링 실패: {response.status}")
+                print(f"응답 내용: {response_text}")
+                return None
+            
+async def fetch_monthly_league_schedule(year_month_str: str, league_str: str):
+    url = 'https://esports-api.game.naver.com/service/v2/schedule/month'
+
+    params = {
+        'month': year_month_str,
+        'topLeagueId': league_str,
+        'relay': 'false'
+    }
+
+    headers = {
+        'origin': 'https://game.naver.com',
+        'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Whale/4.32.315.22 Safari/537.36'
+    }
+
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url, params=params, headers=headers) as response:
+            if response.status == 200:
+                data = await response.json()
+                return data
+            else:
+                response_text = await response.text()
+                print(f"❌ 롤 일정 크롤링 실패: {response.status}")
+                print(f"응답 내용: {response_text}")
+
+def _find_team_name(team: dict | None) -> str | None:
+    """팀 객체 딕셔너리에서 사용하기 좋은 이름을 찾아 반환합니다."""
+    if not isinstance(team, dict):
+        return None
+    for key in _TEAM_NAME_KEYS:
+        val = team.get(key)
+        if val:
+            return str(val)
+    return None
+
+
+def _normalize_start_date(value):
+    """startDate 값이 epoch(ms) 이면 ISO 문자열로 변환하고, 이미 문자열이면 그대로 반환"""
+    if isinstance(value, (int, float)):
+        return datetime.fromtimestamp(value / 1000, tz=timezone.utc).isoformat()
+    return str(value)
+
+def _extract_match_basic(match_obj: dict) -> dict:
+    """내부 match 객체에서 핵심 정보를 추려낸다.
+    반환 필드
+        matchId, startDate(ISO), status, leagueName, blockName, team1, team2
+    일부 필드는 소스 JSON 버전에 따라 키가 다를 수 있어 최대한 유연하게 대응한다.
+    """
+    # 기본 키 매핑
+    match_id = match_obj.get("matchId") or match_obj.get("id")
+    start_date = _normalize_start_date(match_obj.get("startDate") or match_obj.get("startTime"))
+    status = match_obj.get("status") or match_obj.get("matchStatus")
+    league_name = match_obj.get("leagueName") or match_obj.get("league")
+    block_name = match_obj.get("blockName") or match_obj.get("stageName")
+
+    # 점수 추출 (진행 중/종료 경기)
+    score1 = match_obj.get("homeScore") or match_obj.get("team1Score") or match_obj.get("score1")
+    score2 = match_obj.get("awayScore") or match_obj.get("team2Score") or match_obj.get("score2")
+
+    # 팀 추출
+    team1 = team2 = None
+    img1 = img2 = None
+    if "teams" in match_obj and isinstance(match_obj["teams"], list):
+        teams_data = match_obj["teams"]
+        if len(teams_data) >= 1:
+            team1 = _find_team_name(teams_data[0])
+            img1 = _find_team_img(teams_data[0])
+        if len(teams_data) >= 2:
+            team2 = _find_team_name(teams_data[1])
+            img2 = _find_team_img(teams_data[1])
+    elif "homeTeam" in match_obj or "awayTeam" in match_obj:
+        # v2/month 응답 구조 (homeTeam / awayTeam)
+        home = match_obj.get("homeTeam")
+        away = match_obj.get("awayTeam")
+        team1 = _find_team_name(home)
+        team2 = _find_team_name(away)
+        img1 = _find_team_img(home)
+        img2 = _find_team_img(away)
+    else:
+        # 평탄화된 키로 들어오는 경우 (team1Name / team2Name)
+        team1 = match_obj.get("team1Name") or match_obj.get("homeTeamName")
+        team2 = match_obj.get("team2Name") or match_obj.get("awayTeamName")
+
+    return {
+        "matchId": match_id,
+        "startDate": start_date,
+        "status": status,
+        "leagueName": league_name,
+        "blockName": block_name,
+        "team1": team1,
+        "team2": team2,
+        "team1Img": img1,
+        "team2Img": img2,
+        "score1": score1,
+        "score2": score2,
+    }
+
+
+def parse_lol_month_days(days_resp: dict) -> list[dict]:
+    """schedule/month API 응답(JSON)을 받아 날짜 구분 없이 match 단위로 납작하게 반환.
+
+    Args:
+        days_resp (dict): fetch_lol_league_schedule_days() 로 받은 원본 JSON
+
+    Returns:
+        List[Dict]: 경기별 핵심 정보를 담은 리스트
+    """
+    if not days_resp or days_resp.get("code") != 200:
+        return []
+
+    matches: list[dict] = []
+
+    content = days_resp.get("content")
+
+    def _yield_match_objs(node):
+        # content dict (v2) -> matches
+        if isinstance(node, dict):
+            if "matches" in node:
+                for m in node["matches"]:
+                    yield m
+            elif "matchId" in node:
+                yield node
+            else:
+                # date + matchList 구조
+                ml = node.get("matchList") or node.get("matches")
+                if ml:
+                    for m in ml:
+                        yield m
+        elif isinstance(node, list):
+            for item in node:
+                yield from _yield_match_objs(item)
+
+    for obj in _yield_match_objs(content):
+        matches.append(_extract_match_basic(obj))
+
+    return matches
+
+def _find_team_img(team: dict | None) -> str | None:
+    """팀 객체 딕셔너리에서 사용하기 좋은 로고 URL을 찾아 반환합니다."""
+    if not isinstance(team, dict):
+        return None
+    for key in _TEAM_IMG_KEYS:
+        url = team.get(key)
+        if url:
+            return str(url)
+    return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ typing_extensions==4.14.0
 urllib3==2.5.0
 Werkzeug==3.1.3
 yarl==1.20.1
+Pillow>=10.0.0


### PR DESCRIPTION
# 📄 변경 사항 요약
- 네이버 e스포츠 롤 경기 일정 크롤링
- Pillow로 팀 로고·스코어 배너 생성
- 다가오는 4경기(또는 결과 포함) 임베드 전송
- 도움말(/도움) 항목에 일정 기능 설명 보강

## 🔗 관련 이슈
X