### PR TITLE
Fix: 봇 시작 시간 단축 및 Rate Limit 처리 최적화

### DIFF
--- a/cogs/news.py
+++ b/cogs/news.py
@@ -217,7 +217,7 @@ class NewsCommand(commands.Cog):
 
                 if articles_to_send:
                     await safe_send(ctx, f"📢 설정 완료! 최신 뉴스 {len(articles_to_send)}개를 확인했습니다:")
-                    await safe_send(ctx, f"📋 미리보기로 최신 5개를 표시합니다:")
+                    await safe_send(ctx, f"📋 미리보기로 최신 뉴스 {len(articles_to_send) if len(articles_to_send) < 5 else 5}개를 표시합니다:")
                     for article in articles_to_send[-5:]:
                         embed = self.create_news_embed(article)
                         await safe_send(ctx, embed=embed)


### PR DESCRIPTION
# 📄 변경 사항 요약
## Rate Limit 개선사항:
- 최대 재시도 횟수: 5회 → 3회
- 최대 대기 시간: 5분 → 1분
- Rate Limit 임계값: 60분 설정 (기존 1시간)
- Discord retry_after 값 그대로 준수 (60분 이내)
- retry_after 없을 시 지수 백오프 적용

## 시작 프로세스 개선:
- 무한 루프 제거 → 최대 3회 시도로 제한
- LoginFailure 예외 처리로 잘못된 토큰 즉시 감지
- HTTP 에러별 적절한 처리 (401, 403 즉시 종료)
- 일반 에러 시 5초 대기 후 재시도


## 에러 처리 강화:
- safe_send 실패 시 상세 정보 제공
- 채널명, 메시지 내용 포함한 에러 로그
- 사용자 친화적 에러 메시지


## 🔗 관련 이슈
X