### PR TITLE
Refactor: '/리그 [게임명] [리그명]' → '/리그 [게임명]'으로 단순화

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -226,8 +226,6 @@ async def load_cogs():
             print(f'❌ {cog} 로드 실패: {e}')
             print(f'❌ 상세 오류: {type(e).__name__}: {e}')
             failed_cogs.append(cog)
-            import traceback
-            traceback.print_exc()
             
     print(f"\n📊 Cog 로드 결과:")
     print(f"✅ 성공: {len(successful_cogs)}개 - {', '.join(successful_cogs)}")

--- a/crawlers/schedule_crawling.py
+++ b/crawlers/schedule_crawling.py
@@ -79,7 +79,7 @@ async def fetch_lol_league_schedule_months(year_str: str, league_str: str):
                 print(f"응답 내용: {response_text}")
                 return None
             
-async def fetch_monthly_league_schedule(year_month_str: str, league_str: str):
+async def fetch_monthly_lol_league_schedule(year_month_str: str, league_str: str):
     """네이버 e스포츠 API에서 *특정 월*의 경기 일정을 가져옵니다.
 
     `/v2/schedule/month` 엔드포인트를 호출해 주어진 월(YYYYMM)과
@@ -241,7 +241,7 @@ def _find_team_img(team: dict | None) -> str | None:
 
 async def fetch_valorant_league_schedule(league_input: str):
     """
-    발로란트 리그 일정을 크롤링합니다. (시간대 KST로 수정)
+    발로란트 리그 일정을 크롤링합니다.
     """
     # 1. 입력받은 별칭(league_input)으로 표준 키 찾기
     standard_key = VALORANT_LEAGUE_ALIAS.get(league_input.lower())
@@ -256,12 +256,10 @@ async def fetch_valorant_league_schedule(league_input: str):
         print(f"오류: 표준 키 '{standard_key}'에 대한 ID 목록을 찾을 수 없습니다.")
         return None
     
-    # 3. 한국 시간(KST) 기준으로 오늘 ~ 30일 이후 날짜 구하기
-    KST = ZoneInfo("Asia/Seoul")
-    today = datetime.now(KST)
-    end_date = today + timedelta(days=30)
-    from_date_str = today.strftime("%Y-%m-%d")
-    to_date_str = end_date.strftime("%Y-%m-%d")
+    # 3. UTC 기준으로 오늘 ~ 30일 이후 날짜 구하기
+    utc_now = datetime.now(timezone.utc)
+    from_date_str = utc_now.strftime("%Y-%m-%d")
+    to_date_str = (utc_now + timedelta(days=30)).strftime("%Y-%m-%d")
     
     url = "https://esports.op.gg/valorant/graphql/__query__GetMatchesBySeries"
     headers = {


### PR DESCRIPTION
# 📄 변경 사항 요약
- 명령어 단축: /리그 [게임명] [리그명] → /리그 [게임명]

- 작동 방식: 게임명만 입력하면 해당 게임의 모든 리그를 버튼으로 표시하고, 버튼 클릭 시 선택한 리그의 일정을 보여줍니다.

<img width="558" height="157" alt="image" src="https://github.com/user-attachments/assets/b5985ec6-a786-4fc5-bb82-6b14d9f65176" />

## 🔗 관련 이슈
- Closes #55